### PR TITLE
Added script to run to generate index page

### DIFF
--- a/docs/header.md
+++ b/docs/header.md
@@ -1,0 +1,7 @@
+# Developer documentation for Coop
+
+See [Getting started](getting-started) for how to request a client and how to get started with OAuth. Make sure you read the [introduction to OAauth](introduction-to-oauth). 
+
+Once you have a client, you can inspect [scopes and audiences](scopes-and-audience) defined per client. 
+
+Ready for production? Review our [pre-flight checklist](production-checklist) before launching your app. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,3 +5,12 @@ See [Getting started](getting-started) for how to request a client and how to ge
 Once you have a client, you can inspect [scopes and audiences](scopes-and-audience) defined per client. 
 
 Ready for production? Review our [pre-flight checklist](production-checklist) before launching your app. 
+
+### Table of contents:
+
+* [Api-development](#$api-development)
+* [Getting-started](#$getting-started)
+* [Introduction-to-oauth](#$introduction-to-oauth)
+* [Production-checklist](#$production-checklist)
+* [Scopes-and-audience](#$scopes-and-audience)
+* [Token-deepdive](#$token-deepdive)

--- a/make-index.py
+++ b/make-index.py
@@ -1,0 +1,37 @@
+""" Build index from directory listing
+make_index.py </path/to/directory>
+"""
+
+import os
+import argparse
+from mako.template import Template
+
+INDEX_TEMPLATE = r"""
+
+
+Table of contents:
+% for name in names:
+   * [${name.capitalize()}](#${name})
+% endfor
+"""
+EXCLUDED = ['index.md','header.md']
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("directory")
+    args = parser.parse_args()
+    fnames = [fname.removesuffix(".md") for fname in sorted(os.listdir(args.directory))
+              if fname not in EXCLUDED]
+    with open("./docs/header.md","r") as f:
+        index = open("./docs/index.md","w+")
+        index.write(f.read())
+        index.write(template(fnames))
+        f.close()
+        index.close()
+def template(fnames):
+    result = '\n\n### Table of contents:\n\n'
+    for f in fnames:
+        result += "* [{}](#${})\n".format(f.capitalize(),f)
+    return result
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
You can now run `python3 make-index.py docs` from the top directory to generate a table of contents together with the index header specified in `docs/header.md`